### PR TITLE
Remove `ccd-profile` vault

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -8,19 +8,6 @@ module "shared-vault" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   product_group_object_id = "be8b3850-998a-4a66-8578-da268b8abd6b"
 }
-  
-# FIXME Temporary fix
-  
-module "user-profile-vault" {
-  source              = "git@github.com:hmcts/moj-module-key-vault?ref=master"
-  name                = "ccd-profile-${var.env}" // Max 24 characters
-  product             = "${var.product}"
-  env                 = "${var.env}"
-  tenant_id           = "${var.tenant_id}"
-  object_id           = "${var.jenkins_AAD_objectId}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  product_group_object_id = "be8b3850-998a-4a66-8578-da268b8abd6b"
-}
 
 output "vaultName" {
   value = "${module.shared-vault.key_vault_name}"


### PR DESCRIPTION
Once migration to new vault has been completed in production, aat and demo; the ccd-profile vault can be removed from the infrastructure.