### PR TITLE
Vault: remove ccd-shared-$env vault

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,14 +1,3 @@
-module "shared-vault" {
-  source = "git@github.com:hmcts/cnp-module-key-vault.git?ref=master"
-  name = "ccd-shared-${var.env}"
-  product = "${var.product}"
-  env = "${var.env}"
-  tenant_id = "${var.tenant_id}"
-  object_id = "${var.jenkins_AAD_objectId}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  product_group_object_id = "be8b3850-998a-4a66-8578-da268b8abd6b"
-}
-
 module "vault" {
   source = "git@github.com:hmcts/cnp-module-key-vault.git?ref=master"
   name = "ccd-${var.env}"
@@ -21,9 +10,9 @@ module "vault" {
 }
 
 output "vaultName" {
-  value = "${module.shared-vault.key_vault_name}"
+  value = "${module.vault.key_vault_name}"
 }
 
 output "vaultUri" {
-  value = "${module.shared-vault.key_vault_uri}"
+  value = "${module.vault.key_vault_uri}"
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2484



This initial vault doesn't match the expected naming, now that we don't
use it in any of the apps we can remove.




**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No