### PR TITLE
Lock shared resource group

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -9,6 +9,14 @@ module "vault" {
   product_group_object_id = "be8b3850-998a-4a66-8578-da268b8abd6b"
 }
 
+resource "azurerm_management_lock" "vault" {
+  count      = 1
+  name       = "resource-vault"
+  scope      = "${module.vault.key_vault_id}"
+  lock_level = "CanNotDelete"
+  notes      = "Lock vault as it is needed by other apps."
+}
+
 output "vaultName" {
   value = "${module.vault.key_vault_name}"
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2959



Prevent accidental or intentional deletion of the resoure group since
there are other apps using the Vault, Shared Storage and App Service
Plans created by the resource we can't allow them to be unintentionally
deleted.



**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No