### PR TITLE
Jenkins: surface build failures to slack

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -7,6 +7,7 @@ import uk.gov.hmcts.contino.Environment
 Environment environment = new Environment(env)
 
 onMaster {
+  enableSlackNotifications('#ccd-master-builds')
   sharedInfrastructurePipeline('ccd', environment.nonProdName, 'nonprod')
   sharedInfrastructurePipeline('ccd', environment.demoName, 'nonprod')
   sharedInfrastructurePipeline('ccd', environment.prodName, 'prod')

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -9,4 +9,5 @@ properties([
 		])
 ])
 
+enableSlackNotifications('#ccd-param-builds')
 sharedInfrastructurePipeline('ccd', params.ENVIRONMENT, 'sandbox')


### PR DESCRIPTION
Ensure we have notifications for build failures, but break them out so that
relevant channels are used for master, and sandbox* envs.

RDM-2947




https://tools.hmcts.net/jira/browse/RDM-2947





**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No