### PR TITLE
Add shared application insight

### DIFF
--- a/appinsights.tf
+++ b/appinsights.tf
@@ -1,0 +1,10 @@
+resource "azurerm_application_insights" "appinsights" {
+  name                = "${var.product}-${var.env}"
+  location            = "${var.appinsights_location}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+  application_type    = "${var.application_type}"
+}
+
+output "appInsightsInstrumentationKey" {
+  value = "${azurerm_application_insights.appinsights.instrumentation_key}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,21 @@ variable "asp_capacity" {
 }
 
 
+// Application Insight Variables
+// UK South is unavailable for Application Insights
+variable "appinsights_location" {
+  type = "string"
+  default = "West Europe"
+  description = "Location for Application Insights"
+}
+
+variable "application_type" {
+  type = "string"
+  default = "Web"
+  description = "Type of Application Insights (Web/Other)"
+}
+
+
 // TAG SPECIFIC VARIABLES
 variable "team_name" {
   type        = "string"


### PR DESCRIPTION
A single app insight instance to be used across all applications.

RDM-2618




https://tools.hmcts.net/jira/browse/RDM-2618



Seems it really is this simple.  TF exports the key, Jenkins shared
infra builder puts it into the shared vault (not sure why TF doesn't do
that). When deploying the webapp.  Jenkins checks to see if the key is
in the $prod-$env vault and uses it if it exists.  If it doesn't it does
a per app appinsight.



**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No