### PR TITLE
RDM-3272 Palo Alto configuration changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@
 *.tfstate.*
 
 # .tfvars files
-*.tfvars
+#*.tfvars
+
+# IntelliJ IDEA files
+.idea/
+*.iml

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway-ccd.aat.platform.hmcts.net"
+external_hostname_www = "www-ccd.aat.platform.hmcts.net"
+external_cert_name = "STAR-aat"

--- a/app-gateway.tf
+++ b/app-gateway.tf
@@ -1,0 +1,249 @@
+data "azurerm_key_vault_secret" "cert" {
+  name      = "${var.external_cert_name}"
+  vault_uri = "https://infra-vault-${var.subscription}.vault.azure.net/"
+}
+
+
+data "azurerm_subnet" "ase_subnet" {
+  name                 = "core-infra-subnet-0-${var.env}"
+  virtual_network_name = "core-infra-vnet-${var.env}"
+  resource_group_name  = "core-infra-${var.env}"
+}
+
+module "appGw" {
+  source            = "git@github.com:hmcts/cnp-module-waf?ref=ccd/CHG0033576"
+  env               = "${var.env}"
+  subscription      = "${var.subscription}"
+  location          = "${var.location}"
+  wafName           = "${var.product}-appGW"
+  resourcegroupname = "${azurerm_resource_group.rg.name}"
+  use_authentication_cert = "true"
+
+  # vNet connections
+  gatewayIpConfigurations = [
+    {
+      name     = "internalNetwork"
+      subnetId = "${data.azurerm_subnet.ase_subnet.id}"
+    },
+  ]
+
+  sslCertificates = [
+    {
+      name     = "${var.external_cert_name}"
+      data     = "${data.azurerm_key_vault_secret.cert.value}"
+      password = ""
+    },
+  ]
+
+  # Http Listeners
+  httpListeners = [
+    {
+      name                    = "${var.product}-http-listener-gateway"
+      FrontendIPConfiguration = "appGatewayFrontendIP"
+      FrontendPort            = "frontendPort80"
+      Protocol                = "Http"
+      SslCertificate          = ""
+      hostName                = "${var.external_hostname_gateway}"
+    },
+    {
+      name                    = "${var.product}-https-listener-gateway"
+      FrontendIPConfiguration = "appGatewayFrontendIP"
+      FrontendPort            = "frontendPort443"
+      Protocol                = "Https"
+      SslCertificate          = "${var.external_cert_name}"
+      hostName                = "${var.external_hostname_gateway}"
+    },
+    {
+      name                    = "${var.product}-http-listener-www"
+      FrontendIPConfiguration = "appGatewayFrontendIP"
+      FrontendPort            = "frontendPort80"
+      Protocol                = "Http"
+      SslCertificate          = ""
+      hostName                = "${var.external_hostname_www}"
+    },
+    {
+      name                    = "${var.product}-https-listener-www"
+      FrontendIPConfiguration = "appGatewayFrontendIP"
+      FrontendPort            = "frontendPort443"
+      Protocol                = "Https"
+      SslCertificate          = "${var.external_cert_name}"
+      hostName                = "${var.external_hostname_www}"
+    },
+  ]
+
+  # Backend address Pools
+  backendAddressPools = [
+    {
+      name = "${var.product}-${var.env}-palo-alto"
+      backendAddresses = "${module.palo_alto.untrusted_ips_fqdn}"
+    },
+    {
+      name = "${var.product}-${var.env}-backend-pool"
+      backendAddresses = [
+        {
+          ipAddress = "${var.ilbIp}"
+        },
+      ]
+    },
+  ]
+
+  backendHttpSettingsCollection = [
+    {
+      name                           = "backend-80-nocookies-gateway"
+      port                           = 80
+      Protocol                       = "Http"
+      AuthenticationCertificates     = ""
+      CookieBasedAffinity            = "Disabled"
+      probeEnabled                   = "True"
+      probe                          = "http-probe-gateway"
+      PickHostNameFromBackendAddress = "False"
+      HostName                       = "${var.external_hostname_gateway}"
+    },
+    {
+      name                           = "backend-443-nocookies-gateway"
+      port                           = 443
+      Protocol                       = "Https"
+      AuthenticationCertificates     = "ilbCert"
+      CookieBasedAffinity            = "Disabled"
+      probeEnabled                   = "True"
+      probe                          = "https-probe-gateway"
+      PickHostNameFromBackendAddress = "False"
+      HostName                       = "${var.external_hostname_gateway}"
+    },
+    {
+      name                           = "backend-80-nocookies-www"
+      port                           = 80
+      Protocol                       = "Http"
+      AuthenticationCertificates     = ""
+      CookieBasedAffinity            = "Disabled"
+      probeEnabled                   = "True"
+      probe                          = "http-probe-www"
+      PickHostNameFromBackendAddress = "False"
+      HostName                       = "${var.external_hostname_www}"
+    },
+    {
+      name                           = "backend-443-nocookies-www"
+      port                           = 443
+      Protocol                       = "Https"
+      AuthenticationCertificates     = "ilbCert"
+      CookieBasedAffinity            = "Disabled"
+      probeEnabled                   = "True"
+      probe                          = "https-probe-www"
+      PickHostNameFromBackendAddress = "False"
+      HostName                       = "${var.external_hostname_www}"
+    },
+  ]
+
+  # Request routing rules
+  requestRoutingRules = [
+    {
+      name                = "http-www"
+      ruleType            = "Basic"
+      httpListener        = "${var.product}-http-listener-www"
+      backendAddressPool  = "${var.product}-${var.env}-backend-pool"
+      backendHttpSettings = "backend-80-nocookies-www"
+    },
+    {
+      name                = "https-www"
+      ruleType            = "Basic"
+      httpListener        = "${var.product}-https-listener-www"
+      backendAddressPool  = "${var.product}-${var.env}-backend-pool"
+      backendHttpSettings = "backend-443-nocookies-www"
+    }
+  ]
+
+  requestRoutingRulesPathBased = [
+    {
+      name                = "http-gateway"
+      ruleType            = "PathBasedRouting"
+      httpListener        = "${var.product}-http-listener-gateway"
+      urlPathMap          = "http-url-path-map-gateway"
+    },
+    {
+      name                = "https-gateway"
+      ruleType            = "PathBasedRouting"
+      httpListener        = "${var.product}-https-listener-gateway"
+      urlPathMap          = "https-url-path-map-gateway"
+    }
+  ]
+
+  urlPathMaps = [
+    {
+      name                       = "http-url-path-map-gateway"
+      defaultBackendAddressPool  = "${var.product}-${var.env}-backend-pool"
+      defaultBackendHttpSettings = "backend-80-nocookies-gateway"
+      pathRules                  = [
+        {
+          name                = "http-url-path-map-gateway-rule-palo-alto"
+          paths               = ["/documents"]
+          backendAddressPool  = "${var.product}-${var.env}-palo-alto"
+          backendHttpSettings = "backend-80-nocookies-gateway"
+        }
+      ]
+    },
+    {
+      name                       = "https-url-path-map-gateway"
+      defaultBackendAddressPool  = "${var.product}-${var.env}-backend-pool"
+      defaultBackendHttpSettings = "backend-80-nocookies-gateway"
+      pathRules                  = [
+        {
+          name                = "https-url-path-map-gateway-rule-palo-alto"
+          paths               = ["/documents"]
+          backendAddressPool  = "${var.product}-${var.env}-palo-alto"
+          backendHttpSettings = "backend-80-nocookies-gateway"
+        }
+      ]
+    }
+  ]
+
+  probes = [
+    {
+      name                                = "http-probe-gateway"
+      protocol                            = "Http"
+      path                                = "/"
+      interval                            = "${var.health_check_interval}"
+      timeout                             = "${var.health_check_timeout}"
+      unhealthyThreshold                  = "${var.unhealthy_threshold}"
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "backend-80-nocookies-gateway"
+      host                                = "${var.external_hostname_gateway}"
+      healthyStatusCodes                  = "200-404"                  // MS returns 400 on /, allowing more codes in case they change it
+    },
+    {
+      name                                = "https-probe-gateway"
+      protocol                            = "Https"
+      path                                = "/"
+      interval                            = "${var.health_check_interval}"
+      timeout                             = "${var.health_check_timeout}"
+      unhealthyThreshold                  = "${var.unhealthy_threshold}"
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "backend-443-nocookies-gateway"
+      host                                = "${var.external_hostname_gateway}"
+      healthyStatusCodes                  = "200-399"
+    },
+    {
+      name                                = "http-probe-www"
+      protocol                            = "Http"
+      path                                = "/"
+      interval                            = "${var.health_check_interval}"
+      timeout                             = "${var.health_check_timeout}"
+      unhealthyThreshold                  = "${var.unhealthy_threshold}"
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "backend-80-nocookies-www"
+      host                                = "${var.external_hostname_www}"
+      healthyStatusCodes                  = "200-404"                  // MS returns 400 on /, allowing more codes in case they change it
+    },
+    {
+      name                                = "https-probe-www"
+      protocol                            = "Https"
+      path                                = "/"
+      interval                            = "${var.health_check_interval}"
+      timeout                             = "${var.health_check_timeout}"
+      unhealthyThreshold                  = "${var.unhealthy_threshold}"
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "backend-443-nocookies-www"
+      host                                = "${var.external_hostname_www}"
+      healthyStatusCodes                  = "200-399"
+    },
+  ]
+}

--- a/demo.tfvars
+++ b/demo.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway-ccd.demo.platform.hmcts.net"
+external_hostname_www = "www-ccd.demo.platform.hmcts.net"
+external_cert_name = "star-demo"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "1.19.0"
+}
+
 locals {
   ase_name = "core-compute-${var.env}"
 

--- a/palo-alto.tf
+++ b/palo-alto.tf
@@ -1,0 +1,15 @@
+module "palo_alto" {
+  source       = "git@github.com:hmcts/cnp-module-palo-alto.git"
+  subscription = "${var.subscription}"
+  env          = "${var.env}"
+  product      = "${var.product}"
+  common_tags  = "${local.tags}"
+
+  untrusted_vnet_name           = "core-infra-vnet-${var.env}"
+  untrusted_vnet_resource_group = "core-infra-${var.env}"
+  untrusted_vnet_subnet_name    = "palo-untrusted"
+  trusted_vnet_name             = "core-infra-vnet-${var.env}"
+  trusted_vnet_resource_group   = "core-infra-${var.env}"
+  trusted_vnet_subnet_name      = "palo-trusted"
+  trusted_destination_ip        = "${var.ilbIp}"
+}

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway.ccd.platform.hmcts.net"
+external_hostname_www = "www.ccd.platform.hmcts.net"
+external_cert_name = "ccd.platform.hmcts.net.shutter"

--- a/saat.tfvars
+++ b/saat.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway-ccd.saat.platform.hmcts.net"
+external_hostname_www = "www-ccd.saat.platform.hmcts.net"
+external_cert_name = "STAR-saat-platform-hmcts-net"

--- a/sandbox.tfvars
+++ b/sandbox.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway-ccd.sandbox.platform.hmcts.net"
+external_hostname_www = "www-ccd.sandbox.platform.hmcts.net"
+external_cert_name = "STAR-sandbox-platform-hmcts-net"

--- a/sprod.tfvars
+++ b/sprod.tfvars
@@ -1,0 +1,3 @@
+external_hostname_gateway = "gateway-ccd.sprod.platform.hmcts.net"
+external_hostname_www = "www-ccd.sprod.platform.hmcts.net"
+external_cert_name = "STAR-sprod-platform-hmcts-net"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,14 @@ variable "env" {
   description = "The deployment environment (sandbox, aat, prod etc..)"
 }
 
+variable "subscription" {
+  type = "string"
+}
+
+variable "ilbIp" {
+  type = "string"
+}
+
 variable "location" {
   type    = "string"
   description = "The location where you would like to deploy your infrastructure"

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,28 @@ variable "destroy_me" {
   description = "Here be dragons! In the future if this is set to Yes then automation will delete this resource on a schedule. Please set to No unless you know what you are doing"
   default     = "No"
 }
+
+variable "external_cert_name" {
+  type = "string"
+}
+
+variable "external_hostname_gateway" {
+  type = "string"
+}
+
+variable "external_hostname_www" {
+  type = "string"
+}
+
+// http parameters
+variable "health_check_interval" {
+  default = "30"
+}
+
+variable "health_check_timeout" {
+  default = "30"
+}
+
+variable "unhealthy_threshold" {
+  default = "5"
+}


### PR DESCRIPTION
Create a new CCD application gateway resource to divert all requests to /documents path to Palo Alto for AV inspection. All other requests will go through the ccd-api-gateway as usual. The documents containing any virus would be rejected by the Palo Alto module.

See https://tools.hmcts.net/jira/browse/RDM-3272 for detailed design.