### PR TITLE
RDM-6926 Increase max uplolad file size limit and SKU + request timeout for documents in one PR

### DIFF
--- a/app-gateway.tf
+++ b/app-gateway.tf
@@ -24,9 +24,10 @@ module "appGw" {
   wafName           = "${var.product}-appGW"
   resourcegroupname = "${azurerm_resource_group.rg.name}"
   use_authentication_cert = "true"
-  wafFileUploadLimit = "100"
+  wafFileUploadLimit = "${var.file_upload_limit}"
   wafMaxRequestBodySize = "128"
   common_tags = "${local.tags}"
+  size              = "WAF_Large"
 
   # vNet connections
   gatewayIpConfigurations = [
@@ -109,6 +110,18 @@ module "appGw" {
       HostName                       = "${var.external_hostname_gateway}"
     },
     {
+      name                           = "backend-80-nocookies-gateway-documents"
+      port                           = 80
+      Protocol                       = "Http"
+      AuthenticationCertificates     = ""
+      CookieBasedAffinity            = "Disabled"
+      probeEnabled                   = "True"
+      probe                          = "http-probe-gateway"
+      PickHostNameFromBackendAddress = "False"
+      HostName                       = "${var.external_hostname_gateway}"
+      timeout                        = "${var.documents_request_timeout}"
+    },
+    {
       name                           = "backend-80-nocookies-www"
       port                           = 80
       Protocol                       = "Http"
@@ -175,7 +188,7 @@ module "appGw" {
           name                = "http-url-path-map-gateway-rule-palo-alto"
           paths               = ["/documents"]
           backendAddressPool  = "${var.product}-${var.env}-palo-alto"
-          backendHttpSettings = "backend-80-nocookies-gateway"
+          backendHttpSettings = "backend-80-nocookies-gateway-documents"
         }
       ]
     },
@@ -188,7 +201,7 @@ module "appGw" {
           name                = "https-url-path-map-gateway-rule-palo-alto"
           paths               = ["/documents"]
           backendAddressPool  = "${var.product}-${var.env}-palo-alto"
-          backendHttpSettings = "backend-80-nocookies-gateway"
+          backendHttpSettings = "backend-80-nocookies-gateway-documents"
         }
       ]
     }

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,11 @@ variable "unhealthy_threshold" {
 variable "managed_identity_object_id" {
   default = ""
 }
+
+variable "file_upload_limit" {
+  default = "500"
+}
+
+variable "documents_request_timeout" {
+  default = "300"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-7000


### Change description ###
Timeout periods for the upload/download APIs must be proportionately increased to the below limit.

Note the **timeout** property on **backendHttpSettingsCollection** does not seem to take effect same as other attempts there: requestTimeout, RequestTimeout, request_timeout.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
