### PR TITLE
Fix network whitelisting for storage accounts

### DIFF
--- a/storage-account.tf
+++ b/storage-account.tf
@@ -11,8 +11,8 @@ locals {
   aat_cft_vnet_name           = "cft-aat-vnet"
   aat_cft_vnet_resource_group = "cft-aat-network-rg"
 
-  app_aks_network_name    = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "preview" ? "cft-${local.aks_env}-vnet" : "core-${local.aks_env}-vnet"
-  app_aks_network_rg_name = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "preview" ? "cft-${local.aks_env}-network-rg" : "aks-infra-${local.aks_env}-rg"
+  app_aks_network_name    = var.env != "prod" ? "cft-${local.aks_env}-vnet" : "core-${local.aks_env}-vnet"
+  app_aks_network_rg_name = var.env != "prod" ? "cft-${local.aks_env}-network-rg" : "aks-infra-${local.aks_env}-rg"
 
   standard_subnets = [
     data.azurerm_subnet.jenkins_subnet.id,


### PR DESCRIPTION
### Change description ###
This will allow access to the storage accounts from the new networks for anything other than production


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
