### PR TITLE
Perftest - Update key-vault.tf - DTSPO-13642

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -11,6 +11,7 @@ module "vault" {
   common_tags = local.tags
 
   managed_identity_object_id = var.managed_identity_object_id
+  create_managed_identity    = true
 }
 
 data "azurerm_key_vault" "s2s_vault" {


### PR DESCRIPTION
Creates MI in infra sub to enable workload identity move (not in use until later flux changes)

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x ] No
