### PR TITLE
add plum MI to aat

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,4 +1,4 @@
 ccd_storage_account_enable_data_protection     = true
 dmstore_storage_account_enable_data_protection = true
 managed_identity_object_id                     = "0faad2ca-044c-4b98-9dc7-da94e24fbe00"
-additional_managed_identities_access           = ["plum", "aac"]
+additional_managed_identities_access           = ["plum"]

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,3 +1,4 @@
 ccd_storage_account_enable_data_protection     = true
 dmstore_storage_account_enable_data_protection = true
-managed_identity_object_id                     = ["0faad2ca-044c-4b98-9dc7-da94e24fbe00","f12b8ab0-68d1-4b5d-9c47-d2af46c52ee4"]
+managed_identity_object_id                     = "0faad2ca-044c-4b98-9dc7-da94e24fbe00"
+product_name                                   = ["plum"]

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,3 +1,3 @@
 ccd_storage_account_enable_data_protection     = true
 dmstore_storage_account_enable_data_protection = true
-managed_identity_object_id                     = "0faad2ca-044c-4b98-9dc7-da94e24fbe00"
+managed_identity_object_id                     = ["0faad2ca-044c-4b98-9dc7-da94e24fbe00","f12b8ab0-68d1-4b5d-9c47-d2af46c52ee4"]

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,4 +1,4 @@
 ccd_storage_account_enable_data_protection     = true
 dmstore_storage_account_enable_data_protection = true
 managed_identity_object_id                     = "0faad2ca-044c-4b98-9dc7-da94e24fbe00"
-product_name                                   = ["plum"]
+additional_managed_identities_access           = ["plum", "aac"]

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,5 +1,5 @@
 module "vault" {
-  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-13637"
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
   name                = "ccd-${var.env}"
   product             = var.product
   env                 = var.env

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -10,7 +10,7 @@ module "vault" {
 
   common_tags = local.tags
 
-  managed_identity_object_id = var.managed_identity_object_id
+  managed_identity_object_ids = var.managed_identity_object_id
   create_managed_identity    = true
 }
 

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,5 +1,5 @@
 module "vault" {
-  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-13637"
   name                = "ccd-${var.env}"
   product             = var.product
   env                 = var.env
@@ -11,7 +11,7 @@ module "vault" {
   common_tags = local.tags
 
   managed_identity_object_id = var.managed_identity_object_id
-  product_name               = var.product_name
+  additional_managed_identities_access = var.additional_managed_identities_access
   create_managed_identity    = true
 }
 

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,5 +1,5 @@
 module "vault" {
-  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-13637"
   name                = "ccd-${var.env}"
   product             = var.product
   env                 = var.env
@@ -10,7 +10,8 @@ module "vault" {
 
   common_tags = local.tags
 
-  managed_identity_object_ids = var.managed_identity_object_id
+  managed_identity_object_id = var.managed_identity_object_id
+  product_name               = var.product_name
   create_managed_identity    = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,11 @@ variable "product" {
   default     = "ccd"
 }
 
+variable "additional_managed_identities_access" {
+  type        = list(string)
+  description = "The name of your application"
+}
+
 variable "env" {
   type        = string
   description = "The deployment environment (sandbox, aat, prod etc..)"


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-13637


### Change description ###
Add plum aat MI to CCD aat kv. This is a new approach for other teams using ccd chart / aat vault in preview due to the way workload identity works.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ x ] No
