### PR TITLE
Demo - managed identity in infra sub for WI work

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,6 @@
 {
-  "enabledManagers": ["terraform", "terraform-version"],
-  "labels": ["dependencies"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>hmcts/.github:renovate-config"
+  ]
 }

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -11,6 +11,7 @@ module "vault" {
   common_tags = local.tags
 
   managed_identity_object_id = var.managed_identity_object_id
+  create_managed_identity    = true
 }
 
 data "azurerm_key_vault" "s2s_vault" {


### PR DESCRIPTION
Demo managed identity to be created in infra sub using keyvault module for WI move

Renovate change: `Please note Renovate config is now mandatory in every repo extending default org level config without using enabledManagers`

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ x] No
