### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/appinsights.tf
+++ b/appinsights.tf
@@ -1,33 +1,33 @@
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  tags                = var.common_tags
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  env                 = var.env
+  product             = var.product
+  location            = var.location
+  application_type    = var.application_type
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = var.common_tags
 }
 
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
 output "appInsightsInstrumentationKey" {
   sensitive = true
-  value     = azurerm_application_insights.appinsights.instrumentation_key
+  value     = module.application_insights.instrumentation_key
 }
 
 resource "azurerm_key_vault_secret" "app_insights_key" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.vault.key_vault_id
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.