### PR TITLE
Revert "Add import for jenkins aat"

### DIFF
--- a/import.tf
+++ b/import.tf
@@ -1,4 +1,0 @@
-import {
-  id = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/ccd-shared-aat/providers/Microsoft.KeyVault/vaults/ccd-aat/objectId/14b22215-46e6-48a9-8681-e8cefe66236a"
-  to = module.vault.azurerm_key_vault_access_policy.jenkins[0]
-}


### PR DESCRIPTION
Reverts hmcts/ccd-shared-infrastructure#221

Import no longer needed after successful master run